### PR TITLE
#16 Remove fs.exists check for reopen

### DIFF
--- a/lib/log4node.js
+++ b/lib/log4node.js
@@ -69,11 +69,7 @@ function Log4Node(config) {
         this.file = config.file;
         this.reopen();
         sig_listener.on('SIGUSR2', function() {
-          fs.exists(this.file, function(exists) {
-            if (!exists) {
-              this.reopen();
-            }
-          }.bind(this));
+          this.reopen();
         }.bind(this));
         this.stream.on('error', function(err) {
           console.warn('Unable to write into file : ' + this.file + ' ' + err);


### PR DESCRIPTION
When running multiple processes that are writing to the same log
(not clustered), there is a race condition where the first process
to handle the signal will reopen the file handle (creating the
file), and all other processes will ignore the request because the
file already exists.  This fixes that issue.
