### PR TITLE
Share log file descriptor between cluster master and workers

### DIFF
--- a/lib/log4node.js
+++ b/lib/log4node.js
@@ -48,6 +48,13 @@ cluster.on('online', function(worker) {
   })
 });
 
+var msgListener = new events.EventEmitter();
+if (cluster.isWorker) {
+  process.on('message', function(msg) {
+    msgListener.emit('message', msg);
+  });
+}
+
 function Log4Node(config) {
   config = config || {};
   if (config.parent) {
@@ -60,14 +67,17 @@ function Log4Node(config) {
     this.setLogLevel(config.level);
     this.prefix = config.prefix || "[%d] %l ";
     this.id = config.file || 'stdout';
+    this.file = config.file;
     loggers[this.id] = this;
     if (cluster.isMaster) {
       if (config.file === undefined) {
         this.stream = process.stdout;
       }
       else {
-        this.file = config.file;
         this.reopen();
+        cluster.on('online', function(worker) {
+          worker.send({file: this.file, fd: this.stream.fd});
+        }.bind(this));
         sig_listener.on('SIGUSR2', function() {
           this.reopen();
         }.bind(this));
@@ -75,6 +85,12 @@ function Log4Node(config) {
           console.warn('Unable to write into file : ' + this.file + ' ' + err);
         }.bind(this));
       }
+    } else {
+      msgListener.on('message', function(newConfig) {
+        if (newConfig.file && (newConfig.file === this.file)) {
+          this.reopen(newConfig.fd);
+        }
+      }.bind(this));
     }
   }
 }
@@ -85,11 +101,20 @@ Log4Node.prototype.clone = function(config) {
   return new Log4Node(config);
 }
 
-Log4Node.prototype.reopen = function() {
+Log4Node.prototype.reopen = function(fd) {
   if (this.stream) {
     this.stream.end();
   }
-  this.stream = fs.createWriteStream(this.file, {flags: 'a', encoding: 'utf-8'});
+  var options = {flags: 'a', encoding: 'utf-8'};
+  if (fd) {
+    options["fd"] = fd;
+  }
+  this.stream = fs.createWriteStream(this.file, options);
+  if (cluster.isMaster) {
+    Object.keys(cluster.workers).forEach(function(id) {
+      cluster.workers[id].send({file: this.file, fd: this.stream.fd});
+    }, this);
+  }
 }
 
 Log4Node.prototype.setPrefix = function(prefix) {
@@ -106,7 +131,17 @@ Log4Node.prototype.write = function(msg) {
     this.parent.write(msg);
   }
   else {
-    this.stream.write(msg + '\n');
+    if (this.stream) {
+      this.stream.write(msg + '\n');
+    } else {
+      if (process.connected) {
+        process.send({log: msg, logger_id: this.id});
+      } else {
+        // do no try to send a message to master if disconnected
+        // because in this case node will emit an error event
+        console.warn("Log output not yet initialized for message:", msg);
+      }
+    }
   }
 }
 
@@ -123,18 +158,18 @@ Log4Node.prototype.log = function(level, args) {
             .replace(/%p/, process.pid);
     }
     msg += util.format.apply(this, args);
-    if (cluster.isMaster) {
-      this.write(msg);
-    }
-    else {
-      // do no try to send a message to master if disconnected
-      // because in this case node will emit an error event
-      if (process.connected) {
-        process.send({log: msg, logger_id: this.id});
-      }
-    }
+    this.write(msg);
   }
 }
+
+Log4Node.prototype.close = function() {
+  if (this.stream) {
+    if (this.stream !== process.stdout) {
+      this.stream.end();
+    }
+    this.stream = null;
+  }
+};
 
 // exports
 exports.Log4Node = Log4Node;

--- a/test/test-not-reopening-file.js
+++ b/test/test-not-reopening-file.js
@@ -13,6 +13,9 @@ vows.describe('Test not reopening file').addBatch({
         calls ++;
       };
 
+      log4node.info('log me baby');
+
+      log4node.close();
       process.connected = true;
 
       log4node.info('log me baby');
@@ -30,4 +33,3 @@ vows.describe('Test not reopening file').addBatch({
     }
   }
 }).export(module);
-

--- a/test/test-send-master.js
+++ b/test/test-send-master.js
@@ -13,6 +13,9 @@ vows.describe('Test process.send').addBatch({
         calls ++;
       };
 
+      log4node.info('log me baby');
+
+      log4node.close();
       process.connected = true;
 
       log4node.info('log me baby');
@@ -30,4 +33,3 @@ vows.describe('Test process.send').addBatch({
     }
   }
 }).export(module);
-


### PR DESCRIPTION
Using IPC messaging for sending log lines as multiple issues:

1/ it impacts node process performances: http://www.subbu.org/blog/2012/03/node-js-cost-of-ipc & http://aphyr.com/posts/244-context-switches-and-serialization-in-node
2/ when a worker is disconnected from the master (ex: when using https://github.com/isaacs/cluster-master), workers cannot log anymore

This PR use file descriptor sharing (like it would have been done with any other fork friendly language).
